### PR TITLE
- Removed a redundant agent/script call: the "Hyper-V VM Discovery" L…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,21 @@
 # Changelog
 
 - 2026-06-11
+  - Release v2.0.4
+  - Removed a redundant agent/script call: the "Hyper-V VM Discovery" LLD rule
+    is now a dependent rule on the hyperv.discovery.vms master item instead of
+    polling the agent on its own schedule. Dropped the duplicate
+    hyperv.discover.vms UserParameter from hyper-v.conf. This saves one full
+    ~30s VM enumeration per discovery cycle.
+  - hyper-v-monitoring2.ps1: replaced the remaining deprecated
+    [System.Net.Dns]::GetHostByName() call (the v2.0.3 fix missed one of the
+    two occurrences)
+  - Host dashboard: added a "Hyper-V Host Memory" graph (free memory + memory
+    pressure on a second axis), VMs-running / Total-VMs / vmms-service-state
+    value tiles, and a Current problems widget
+  - VM Guest dashboard: added a Current problems widget
+
+- 2026-06-11
   - Release v2.0.3
   - Added data-collection health triggers on the Hyper-V host template: alert
     when the host data or VM master data item stops receiving data (catches an

--- a/Template_Windows_Hyper-V_Host2.yaml
+++ b/Template_Windows_Hyper-V_Host2.yaml
@@ -12,7 +12,7 @@ zabbix_export:
       name: 'Template Windows Hyper-V Host 2'
       vendor:
         name: 'https://github.com/a-schild/Zabbix-HyperV-Templates'
-        version: '2.0.3'
+        version: '2.0.4'
       description: |
         Detect Hyper-V VMs via LLD and create hosts to monitor
         Needs the Template Windows HyperV VM Guest 2 too
@@ -466,13 +466,20 @@ zabbix_export:
       discovery_rules:
         - uuid: 0bb424a20f1741278efdf0c8c26788ee
           name: 'Hyper-V VM Discovery'
+          type: DEPENDENT
           key: hyperv.discover.vms
-          delay: 1h
+          delay: '0'
           lifetime: 15d
           enabled_lifetime_type: DISABLE_NEVER
           description: |
             HyperV Guest VM Discovery
             Requires PowerShell script installed on HyperV Host.
+
+            Dependent on the 'Hyper-V VMS master data' item (hyperv.discovery.vms)
+            so discovery reuses that data instead of triggering its own separate
+            agent/script invocation.
+          master_item:
+            key: hyperv.discovery.vms
           item_prototypes:
             - uuid: b4982f9f8d1a471db696302f5c26f207
               name: 'Replication Data {#VM.NAME}'
@@ -1015,6 +1022,73 @@ zabbix_export:
                     - type: STRING
                       name: reference
                       value: VCNGI
+                - type: graph
+                  x: '36'
+                  'y': '10'
+                  width: '35'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid.0
+                      value:
+                        host: 'Template Windows Hyper-V Host 2'
+                        name: 'Hyper-V Host Memory'
+                    - type: STRING
+                      name: reference
+                      value: MEMGR
+                - type: item
+                  name: 'VMs running'
+                  'y': '15'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Windows Hyper-V Host 2'
+                        key: hyperv.vms.count.running
+                    - type: STRING
+                      name: reference
+                      value: VRUNN
+                - type: item
+                  name: 'Total VMs'
+                  x: '24'
+                  'y': '15'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Windows Hyper-V Host 2'
+                        key: hyperv.vms.count
+                    - type: STRING
+                      name: reference
+                      value: VTOTL
+                - type: item
+                  name: 'vmms service state'
+                  x: '48'
+                  'y': '15'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Windows Hyper-V Host 2'
+                        key: 'service.info[vmms]'
+                    - type: STRING
+                      name: reference
+                      value: VMMSS
+                - type: problems
+                  name: 'Current problems'
+                  'y': '18'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: reference
+                      value: PROBL
   triggers:
     - uuid: f6a36d3b6d4346ada278f9bf868355e0
       expression: 'last(/Template Windows Hyper-V Host 2/perf_counter_en[\Hyper-V Hypervisor\Virtual Processors])/last(/Template Windows Hyper-V Host 2/perf_counter_en[\Hyper-V Hypervisor\Logical Processors])>5'
@@ -1144,3 +1218,20 @@ zabbix_export:
           item:
             host: 'Template Windows Hyper-V Host 2'
             key: 'perf_counter_en[\Hyper-V Virtual Machine Health Summary\Health Ok]'
+    - uuid: 2276b7161b1c4640b68efe2cb4fd745b
+      name: 'Hyper-V Host Memory'
+      height: '300'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 1E87C8
+          item:
+            host: 'Template Windows Hyper-V Host 2'
+            key: hyperv.host.memory.free
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: F63100
+          yaxisside: RIGHT
+          item:
+            host: 'Template Windows Hyper-V Host 2'
+            key: 'perf_counter_en[\Hyper-V Dynamic Memory Balancer(System Balancer)\Average Pressure,30]'

--- a/Template_Windows_Hyper-V_VM_Guest_2.yaml
+++ b/Template_Windows_Hyper-V_VM_Guest_2.yaml
@@ -13,7 +13,7 @@ zabbix_export:
       name: 'Template Windows Hyper-V VM Guest 2'
       vendor:
         name: 'https://github.com/a-schild/Zabbix-HyperV-Templates'
-        version: '2.0.3'
+        version: '2.0.4'
       description: 'Child template, to create new Hyper-V VM monitoring from the "Template Windows HyperV Host 2" template. See https://github.com/a-schild/Zabbix-HyperV-Templates'
       groups:
         - name: 'HyperV VM'
@@ -1602,3 +1602,12 @@ zabbix_export:
                     - type: STRING
                       name: reference
                       value: WLYNQ
+                - type: problems
+                  name: 'Current problems'
+                  'y': '10'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: reference
+                      value: GPROB

--- a/hyper-v-monitoring2.ps1
+++ b/hyper-v-monitoring2.ps1
@@ -157,7 +157,7 @@ function Get-VMDiscoveryData {
         $hostName = $env:COMPUTERNAME
         $hostFQDN = "Unknown"
         try {
-            $hostFQDN = [System.Net.Dns]::GetHostByName($env:COMPUTERNAME).HostName
+            $hostFQDN = [System.Net.Dns]::GetHostEntry($env:COMPUTERNAME).HostName
             Write-DebugInfo "Host Name: $hostName"
             Write-DebugInfo "Host FQDN: $hostFQDN"
         } catch {

--- a/hyper-v.conf
+++ b/hyper-v.conf
@@ -1,6 +1,7 @@
 # Optimized Hyper-V monitoring with separate VM details discovery
 UserParameter=hyperv.discovery.host,powershell.exe -file "C:\Program Files\Zabbix Agent 2\hyper-v-monitoring2.ps1" "host"
-UserParameter=hyperv.discover.vms,powershell.exe -file "C:\Program Files\Zabbix Agent 2\hyper-v-monitoring2.ps1" "vms"
+# hyperv.discovery.vms feeds the master item; the VM discovery LLD rule now
+# depends on it instead of polling separately (no extra script invocation).
 UserParameter=hyperv.discovery.vms,powershell.exe -file "C:\Program Files\Zabbix Agent 2\hyper-v-monitoring2.ps1" "vms"
 UserParameter=hyperv.discovery.vmdetails[*],powershell.exe -file "C:\Program Files\Zabbix Agent 2\hyper-v-monitoring2.ps1" -DiscoveryType "vmdetails" -VmID "$1"
 


### PR DESCRIPTION
…LD rule

    is now a dependent rule on the hyperv.discovery.vms master item instead of
    polling the agent on its own schedule. Dropped the duplicate
    hyperv.discover.vms UserParameter from hyper-v.conf. This saves one full
    ~30s VM enumeration per discovery cycle.
  - hyper-v-monitoring2.ps1: replaced the remaining deprecated [System.Net.Dns]::GetHostByName() call (the v2.0.3 fix missed one of the two occurrences)
  - Host dashboard: added a "Hyper-V Host Memory" graph (free memory + memory pressure on a second axis), VMs-running / Total-VMs / vmms-service-state value tiles, and a Current problems widget
  - VM Guest dashboard: added a Current problems widget