### PR TITLE
Fix VM discovery on hosts with a single VM (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -41,7 +41,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-/zabbix-hyperv-english-cache.json
-/zabbix-hyperv-localized-cache.json
-/zabbix-hyperv-english-cache.xml
 /.claude

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - 2026-08-10
+  - Release v2.0.5
   - Fix #54: VM discovery failed on Hyper-V hosts with exactly one VM, with
     'Cannot find the "data" array in the received JSON object'. Piping an array
     to ConvertTo-Json unrolls it, so a single VM was emitted as a bare JSON

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+- 2026-08-10
+  - Fix #54: VM discovery failed on Hyper-V hosts with exactly one VM, with
+    'Cannot find the "data" array in the received JSON object'. Piping an array
+    to ConvertTo-Json unrolls it, so a single VM was emitted as a bare JSON
+    object instead of an array. All discovery functions now serialize via
+    ConvertTo-Json -InputObject. Hosts with zero VMs returned empty output
+    before and now correctly return [].
+  - Same fix applied to the embedded {#VM.NETWORK.INFO} / {#VM.DISK.INFO} /
+    {#VM.DVD.INFO} / {#VM.INTEGRATION.INFO} / {#VM.CHECKPOINT.INFO} and
+    {#HOST.VIRTUAL.SWITCHES} payloads, which had the same single-element
+    problem (a VM with one nic, one disk, ...)
+  - Developers.md: removed the stale notes about the xml/json counter cache and
+    the RebuildCache command, which only existed in the v1 script
+
 - 2026-06-11
   - Release v2.0.4
   - Removed a redundant agent/script call: the "Hyper-V VM Discovery" LLD rule

--- a/Developers.md
+++ b/Developers.md
@@ -10,18 +10,13 @@
   Adjust the paths according to the previous step if needed
   __Set UnsafeUserParameters=1 as the performance counters names have \\ in it
 
-- Storing the cache as json does not work, since the names sometimes contain utf8 entities
-  This is why we switched to the xml format for the cache
-
-- The xml cache is rebuilt once a day, which will probably cause some
-  detection timeouts or message errors
-  
 - The whole counter naming is a big mess in windows and even worse 
   when used via powershell.
-  It detects the file age and rebuilds as needed.
-  We could also rebuild it separatly all 23h to prevent
-  interfering with zabbix agent operation
-  
+  The templates therefore use the perf_counter_en[] item key with the
+  english counter paths, and hyper-v-monitoring2.ps1 normalizes localized
+  values (adapter names, vm status, integration services) through the
+  ConvertToEnglish translation table. New localized strings go in there.
+
 - Usually counters and instances are not case sensitive
 - But for the legacy network adapter, in german it's called 
   "Ältere Netzwerkkarte...", you must call the perf counter
@@ -30,5 +25,11 @@
   
 - And the legacy network interface has only counters for bytes and frames sent
   but not for packets
-  
-- `.\hyper-v-monitoring.ps1 RebuildCache`
+
+- To test the script manually on a Hyper-V host:
+```powershell
+.\hyper-v-monitoring2.ps1 host
+.\hyper-v-monitoring2.ps1 vms
+.\hyper-v-monitoring2.ps1 -DiscoveryType vmdetails -VmID <vm-guid>
+.\hyper-v-monitoring2.ps1 vms -Debug   # debug output, breaks the json
+```

--- a/Template_Windows_Hyper-V_Host2.yaml
+++ b/Template_Windows_Hyper-V_Host2.yaml
@@ -12,7 +12,7 @@ zabbix_export:
       name: 'Template Windows Hyper-V Host 2'
       vendor:
         name: 'https://github.com/a-schild/Zabbix-HyperV-Templates'
-        version: '2.0.4'
+        version: '2.0.5'
       description: |
         Detect Hyper-V VMs via LLD and create hosts to monitor
         Needs the Template Windows HyperV VM Guest 2 too

--- a/Template_Windows_Hyper-V_VM_Guest_2.yaml
+++ b/Template_Windows_Hyper-V_VM_Guest_2.yaml
@@ -13,7 +13,7 @@ zabbix_export:
       name: 'Template Windows Hyper-V VM Guest 2'
       vendor:
         name: 'https://github.com/a-schild/Zabbix-HyperV-Templates'
-        version: '2.0.4'
+        version: '2.0.5'
       description: 'Child template, to create new Hyper-V VM monitoring from the "Template Windows HyperV Host 2" template. See https://github.com/a-schild/Zabbix-HyperV-Templates'
       groups:
         - name: 'HyperV VM'

--- a/hyper-v-monitoring2.ps1
+++ b/hyper-v-monitoring2.ps1
@@ -373,11 +373,13 @@ function Get-VMDiscoveryData {
                 "{#VM.DISK.COUNT}" = $vmHardDisks.Count.ToString()
                 "{#VM.DVD.COUNT}" = $vmDvdDrives.Count.ToString()
                 "{#VM.CHECKPOINT.COUNT}" = $checkpoints.Count.ToString()
-                "{#VM.NETWORK.INFO}" = ($networkInfo | ConvertTo-Json -Compress)
-                "{#VM.DISK.INFO}" = ($diskInfo | ConvertTo-Json -Compress)
-                "{#VM.DVD.INFO}" = ($dvdInfo | ConvertTo-Json -Compress)
-                "{#VM.INTEGRATION.INFO}" = ($integrationInfo | ConvertTo-Json -Compress)
-                "{#VM.CHECKPOINT.INFO}" = ($checkpointInfo | ConvertTo-Json -Compress)
+                # -InputObject so a VM with a single nic/disk/dvd/checkpoint still
+                # yields a json array in these embedded payloads, not a bare object
+                "{#VM.NETWORK.INFO}" = (ConvertTo-Json -InputObject $networkInfo -Compress)
+                "{#VM.DISK.INFO}" = (ConvertTo-Json -InputObject $diskInfo -Compress)
+                "{#VM.DVD.INFO}" = (ConvertTo-Json -InputObject $dvdInfo -Compress)
+                "{#VM.INTEGRATION.INFO}" = (ConvertTo-Json -InputObject $integrationInfo -Compress)
+                "{#VM.CHECKPOINT.INFO}" = (ConvertTo-Json -InputObject $checkpointInfo -Compress)
                 "{#VM.REPLICATION.ENABLED}" = $replicationEnabled.ToString()
                 "{#VM.REPLICATION.STATE}" = $replicationState
                 "{#VM.REPLICATION.MODE}" = $replicationMode
@@ -397,13 +399,16 @@ function Get-VMDiscoveryData {
         Write-DebugInfo "Discovery completed. Processed $($discoveryData.Count) VMs"
 
         # Return direct JSON array for Zabbix 7.0+
-        return $discoveryData | ConvertTo-Json -Depth 10
+        # Use -InputObject instead of the pipeline: piping an array unrolls it,
+        # so a host with exactly one VM would emit a bare object instead of an
+        # array and Zabbix LLD fails with 'Cannot find the "data" array'.
+        return ConvertTo-Json -InputObject $discoveryData -Depth 10
 
     } catch {
         Write-DebugInfo "Fatal error in VM discovery: $($_.Exception.Message)"
         Write-DebugInfo "Stack trace: $($_.ScriptStackTrace)"
         # Return empty array in case of error
-        return @() | ConvertTo-Json
+        return ConvertTo-Json -InputObject @()
     }
 }
 
@@ -495,10 +500,11 @@ function Get-VMNetworkDiscovery {
         }
 
         Write-DebugInfo "Network discovery completed. Found $($discoveryData.Count) adapters"
-        return $discoveryData | ConvertTo-Json -Depth 5
+        # -InputObject keeps a single-element result an array, see Get-VMDiscoveryData
+        return ConvertTo-Json -InputObject $discoveryData -Depth 5
     } catch {
         Write-DebugInfo "Error in network discovery: $($_.Exception.Message)"
-        return @() | ConvertTo-Json
+        return ConvertTo-Json -InputObject @()
     }
 }
 
@@ -544,10 +550,11 @@ function Get-VMDiskDiscovery {
         }
 
         Write-DebugInfo "Disk discovery completed. Found $($discoveryData.Count) disks"
-        return $discoveryData | ConvertTo-Json -Depth 5
+        # -InputObject keeps a single-element result an array, see Get-VMDiscoveryData
+        return ConvertTo-Json -InputObject $discoveryData -Depth 5
     } catch {
         Write-DebugInfo "Error in disk discovery: $($_.Exception.Message)"
-        return @() | ConvertTo-Json
+        return ConvertTo-Json -InputObject @()
     }
 }
 
@@ -595,7 +602,8 @@ function Get-HyperVHostInfo {
                     "Extensions" = if ($switch.Extensions) { ($switch.Extensions | ForEach-Object { $_.Name }) -join "," } else { "" }
                 }
             }
-            $hostInfo["{#HOST.VIRTUAL.SWITCHES}"] = ($switchInfo | ConvertTo-Json -Compress)
+            # -InputObject so a host with a single vswitch still yields an array
+            $hostInfo["{#HOST.VIRTUAL.SWITCHES}"] = (ConvertTo-Json -InputObject $switchInfo -Compress)
             $hostInfo["{#HOST.VIRTUAL.SWITCHES.COUNT}"] = $switches.Count.ToString()
             Write-DebugInfo "Found $($switches.Count) virtual switches"
         } catch {
@@ -682,12 +690,14 @@ function Get-HyperVHostInfo {
 
         Write-DebugInfo "Hyper-V host discovery completed"
 
-        # Return as single-item array for Zabbix LLD format
-        return @($hostInfo) | ConvertTo-Json -Depth 10
+        # Return a single JSON object (NOT an array): the host template's
+        # dependent items address it directly, e.g. $["{#HOST.VM.TOTAL.COUNT}"]
+        return ConvertTo-Json -InputObject $hostInfo -Depth 10
 
     } catch {
         Write-DebugInfo "Fatal error in host discovery: $($_.Exception.Message)"
-        return @() | ConvertTo-Json
+        # Keep the object shape so dependent items get valid JSON
+        return ConvertTo-Json -InputObject @{}
     }
 }
 


### PR DESCRIPTION
Fixes #54.

Piping an array into `ConvertTo-Json` makes PowerShell unroll the pipeline, so the cmdlet receives the elements individually instead of the array. On a host with exactly one VM that produced a bare JSON object rather than a one-element array, and Zabbix LLD rejected it with `Cannot find the "data" array in the received JSON object`. A host with zero VMs was worse — the item returned no output at all.

| VMs on host | before | after |
|---|---|---|
| 0 | *(no output)* | `[]` |
| 1 | `{"{#VM.NAME}":"vm1"}` | `[{"{#VM.NAME}":"vm1"}]` |
| 2 | `[{...},{...}]` | unchanged |

All discovery functions now serialize with `ConvertTo-Json -InputObject`, which does not unroll. `-AsArray` would be tidier but needs PowerShell 6+, and the agent runs Windows PowerShell 5.1. The same correction is applied to the embedded `{#VM.NETWORK.INFO}`, `{#VM.DISK.INFO}`, `{#VM.DVD.INFO}`, `{#VM.INTEGRATION.INFO}`, `{#VM.CHECKPOINT.INFO}` and `{#HOST.VIRTUAL.SWITCHES}` payloads, which hit the same problem for any VM with a single nic or disk.

`Get-HyperVHostInfo` intentionally keeps returning a single object: its comment claimed a single-item array, but the unrolling meant it has always emitted an object, and the host template addresses it that way (`$["{#HOST.VM.TOTAL.COUNT}"]`). Output there is unchanged, only the misleading comment is fixed.

Also in this branch:
- Removed the stale xml/json counter-cache notes and the `RebuildCache` command from `Developers.md` — those only existed in the v1 script — and the matching dead entries from `.gitignore`. The `.gitignore` diff looks large because the file was committed with mixed line endings and `text=auto` normalizes them; only three lines actually changed.
- Bumped the template vendor version to 2.0.5.

Verified on Windows PowerShell 5.1: script parses clean, UTF-8 BOM preserved, host object shape byte-identical, `vmdetails` unaffected (arrays nested in a hashtable do not unroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
