### PR TITLE
ci: put the version back in the release asset name

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Create artifact
         uses: montudor/action-zip@v1
         with:
-          args: zip -X -r ${{ github.event.repository.name }}.${{ github.ref.name }}.zip . -x *.git* 
+          args: zip -X -r ${{ github.event.repository.name }}.${{ github.ref_name }}.zip . -x *.git*
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.event.repository.name }}.${{ github.ref.name }}.zip
-          asset_name: Zabbix-HyperV-Templates.${{ github.ref.name }}.zip
+          file: ${{ github.event.repository.name }}.${{ github.ref_name }}.zip
+          asset_name: Zabbix-HyperV-Templates.${{ github.ref_name }}.zip
           tag: ${{ github.ref }}
           overwrite: true
 #          body: "This is my release text"


### PR DESCRIPTION
`github.ref.name` is not a valid expression — `github.ref` is a plain string (`refs/tags/v2.0.5`), so `.name` resolved to empty. Every release since has shipped an asset called `Zabbix-HyperV-Templates.zip` with no version in the filename; v2.0.3, v2.0.4 and v2.0.5 all have identically named downloads.

Switched to `github.ref_name`, which yields the tag name itself. The next tagged release will produce `Zabbix-HyperV-Templates.v2.0.6.zip`.

Existing release assets are left untouched — renaming them would break any links people already have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
