### PR TITLE
Checkpoint monitoring and the rest of vm_info (#47, #45, #40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,19 @@ everything else is `DEPENDENT` on it:
   call the script. VM counts, replication items, the `Hyper-V VM Discovery` LLD rule and the
   `Hyper-V VM Host Prototype Discovery` rule all hang off them as dependent items/rules.
 - Guest template: `hyperv.discovery.vmdetails[{$VM.ID}]` is the single master item; the three LLD
-  rules (disks, regular NICs, legacy NICs) and all their dependent items parse it.
+  rules (disks, regular NICs, legacy NICs) and ~38 template-level items parse it. Its payload has
+  four roots — `vm_info`, `networks`, `disks`, `checkpoints`.
 
 When adding anything, make it dependent on an existing master item. A new LLD rule or item that
 polls the agent directly costs another full enumeration per interval.
+
+**Know what a poll actually costs.** The vmdetails master item runs once *per VM per interval*,
+and each run starts a `powershell.exe`, imports the Hyper-V module and calls `Get-VHD` on every
+disk. On a 20-VM host a 10-minute interval is a fresh PowerShell every 30 seconds — the cause of
+the CPU spikes in issue #40. The interval is the `{$VM.DETAILS.INTERVAL}` macro (default 30m).
+Separately, the guest template's `perf_counter_en[...]` prototypes poll at 1m and there are ~21
+per disk and ~19 per NIC, so a VM with two disks and a NIC is ~60 agent queries a minute. Those
+are agent-side and cheap individually, but they multiply by VM count.
 
 **Host prototypes create the VM hosts.** `Hyper-V VM Host Prototype Discovery` creates one Zabbix
 host per VM named `{#VM.ID} {#VMHOST.FQDN}` and sets `{$VM.ID}`/`{$VMHOST.FQDN}` on it. That

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,12 +24,23 @@
   - {#VM.INTEGRATION.INFO} is now part of the vmdetails payload too.
     Get-VMIntegrationService was already being called there and its result
     discarded.
-  - Performance (#40): the VM details poll interval is now the
-    {$VM.DETAILS.INTERVAL} macro and defaults to 30m instead of 10m. Every
-    poll starts a powershell.exe, imports the Hyper-V module and runs Get-VHD
-    over each disk, once per VM. On a host with 20 VMs the old 10m interval
-    meant one such run every 30 seconds, which matches the reported symptom.
-    Lower the macro if faster VM state detection matters more than host CPU.
+  - Performance (#40):
+    - The VM details poll interval is now the {$VM.DETAILS.INTERVAL} macro.
+      The default stays 10m, so nothing changes unless you tune it. Every poll
+      starts a powershell.exe, imports the Hyper-V module and runs Get-VHD over
+      each disk, once per VM, so on a host with 20 VMs the 10m default is one
+      such run every 30 seconds. Raise the macro to 30m or 60m on busy hosts.
+    - The 21 disk performance counters now poll every 5m instead of every 1m.
+      16 of them are queried on demand, so that is five times fewer agent
+      queries per disk per VM.
+    - The five disk counters that carry an averaging window (latency, read and
+      write bytes/sec, read and write operations/sec) now average over 300s
+      instead of 30s, so the value covers the whole 5m interval rather than
+      sampling 30 seconds out of every 300. Note this changes their item key,
+      so Zabbix treats them as new items and their history starts fresh.
+      The agent samples these counters once a second regardless of the polling
+      interval, so the change is about data quality, not agent load.
+    - Network counters are left at 1m.
   - Refactor: checkpoint and integration service collection moved into
     Get-CheckpointSummary / Get-IntegrationServiceInfo so both payloads expose
     identical fields instead of duplicating the loops.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
-- 2026-08-10 (unreleased)
+- 2026-08-10
+  - Release v2.0.6
   - Checkpoint monitoring (#47). The script already collected checkpoints but
     nothing consumed them. hyper-v-monitoring2.ps1 now also reports the oldest
     and newest checkpoint (name, creation time, epoch and age) in both the

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,57 @@
 # Changelog
 
+- 2026-08-10 (unreleased)
+  - Checkpoint monitoring (#47). The script already collected checkpoints but
+    nothing consumed them. hyper-v-monitoring2.ps1 now also reports the oldest
+    and newest checkpoint (name, creation time, epoch and age) in both the
+    'vms' and the 'vmdetails' payload, and the VM Guest template exposes count,
+    type, oldest/newest name, creation time and age, plus the raw list.
+    Two new triggers: too many checkpoints ({$VM.CHECKPOINT.COUNT.MAX},
+    default 3) and a checkpoint left behind ({$VM.CHECKPOINT.AGE.MAX},
+    default 7d). Ages are computed on the Hyper-V host, so the Zabbix server
+    does not have to guess the host's timezone.
+  - The whole vm_info block was collected every poll and thrown away: no item
+    in either template read a single field of it (#45 "I dont see any
+    informations about the VMs like memory, CPU only Disks and NICs"). The VM
+    Guest template now has 38 dependent items covering state, status, uptime,
+    generation, configuration version, vCPU count/reserve/limit/weight, memory
+    startup/min/max/dynamic/buffer/weight, autostart and autostop behaviour,
+    config/checkpoint/smart-paging paths, notes, adapter/disk/dvd counts and
+    the integration services. All are dependent on the existing master item,
+    so they cost no additional agent or script calls.
+  - Two new triggers on VM health: status not 'Operating normally' (warning)
+    and VM not running (info, disable where VMs are legitimately off).
+  - {#VM.INTEGRATION.INFO} is now part of the vmdetails payload too.
+    Get-VMIntegrationService was already being called there and its result
+    discarded.
+  - Performance (#40): the VM details poll interval is now the
+    {$VM.DETAILS.INTERVAL} macro and defaults to 30m instead of 10m. Every
+    poll starts a powershell.exe, imports the Hyper-V module and runs Get-VHD
+    over each disk, once per VM. On a host with 20 VMs the old 10m interval
+    meant one such run every 30 seconds, which matches the reported symptom.
+    Lower the macro if faster VM state detection matters more than host CPU.
+  - Refactor: checkpoint and integration service collection moved into
+    Get-CheckpointSummary / Get-IntegrationServiceInfo so both payloads expose
+    identical fields instead of duplicating the loops.
+  - Fixed three further problems reported in #45:
+    - The 'Replication Data' item prototype was a dependent item with no
+      preprocessing and no explicit value type, so it defaulted to
+      Numeric (unsigned) and received the entire VM array. It failed on every
+      discovered VM with 'Value of type "string" is not suitable for value type
+      "Numeric (unsigned)"'. It is now a TEXT item that extracts just its own
+      VM's record. Its key also had a stray $ (hyperv.vm.data[${#VM.ID}]).
+    - The replication items threw ZBX_UNSUPPORTED whenever a field was empty,
+      which is the normal case for a VM without replication: no primary
+      server, no replica server and no last sync time. Every non replicated VM
+      therefore had three permanently unsupported items. They now return an
+      empty value ("0" for the numeric replication frequency) and only throw
+      when the VM itself is missing from the payload.
+    - The calculated 'Hyper-V Host free memory' item needs vm.memory.size[total]
+      and vm.memory.size[used], which come from a windows agent template and
+      not from this one. That requirement is now documented in the item, in the
+      template description and in the readme, instead of surfacing as
+      'Cannot evaluate function: item ... does not exist'.
+
 - 2026-08-10
   - Release v2.0.5
   - Fix #54: VM discovery failed on Hyper-V hosts with exactly one VM, with

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Set-AuthenticodeSignature -Certificate $cert `
 * Set-up Hyper-V host in Zabbix interface. 
 	* Add a new host, if needed.
 	* Link it with "Template Windows HyperV Host" template. 
+	* **Also link a Windows agent template** to the same host, for example
+	  "Windows by Zabbix agent". The host memory items of the Hyper-V template
+	  are calculated from `vm.memory.size[total]` and `vm.memory.size[used]`,
+	  which come from that template. Without it you get
+	  `Cannot evaluate function: item "vm.memory.size[total]" does not exist`
+	  and the memory graph stays empty.
 	* Wait for a guest discovery to fire, it will:
 		* discover Hyper-V guests, 
 		* create a new host for each VM,

--- a/Template_Windows_Hyper-V_Host2.yaml
+++ b/Template_Windows_Hyper-V_Host2.yaml
@@ -16,7 +16,12 @@ zabbix_export:
       description: |
         Detect Hyper-V VMs via LLD and create hosts to monitor
         Needs the Template Windows HyperV VM Guest 2 too
-        
+
+        Link a windows agent template (for example 'Windows by Zabbix agent')
+        to the same host as well. The host memory items of this template are
+        calculated from vm.memory.size[total] / vm.memory.size[used], which
+        that template provides.
+
         See https://github.com/a-schild/Zabbix-HyperV-Templates
       groups:
         - name: Templates
@@ -80,6 +85,17 @@ zabbix_export:
           type: CALCULATED
           key: hyperv.host.memory.free
           params: 'last(//vm.memory.size[total]) - last(//vm.memory.size[used])'
+          description: |
+            Free physical memory on the Hyper-V host.
+
+            REQUIRES a windows agent template to be linked to the same host,
+            for example 'Windows by Zabbix agent' or 'Windows by Zabbix agent
+            active'. The vm.memory.size[total] and vm.memory.size[used] items
+            come from there, not from this template.
+
+            Without it this item stays unsupported with
+            'Cannot evaluate function: item "vm.memory.size[total]" does not
+            exist', and the memory graph on the host dashboard stays empty.
           tags:
             - tag: application
               value: 'Hyper-V Host'
@@ -484,8 +500,38 @@ zabbix_export:
             - uuid: b4982f9f8d1a471db696302f5c26f207
               name: 'Replication Data {#VM.NAME}'
               type: DEPENDENT
-              key: 'hyperv.vm.data[${#VM.ID}]'
+              key: 'hyperv.vm.data[{#VM.ID}]'
               delay: '0'
+              value_type: TEXT
+              trends: '0'
+              description: |
+                Raw discovery record for this VM, kept as a diagnostic aid.
+
+                Without the javascript step below this item received the whole
+                VM array, and being numeric it failed on every VM with
+                'Value of type "string" is not suitable for value type
+                "Numeric (unsigned)"'.
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var data = JSON.parse(value);
+                      var vmId = "{#VM.ID}";
+                      var vmIdMacro = "{"+"#"+"VM.ID}";
+
+                      if (!data || data.length === 0) {
+                        throw "ZBX_UNSUPPORTED: No vm array found";
+                      }
+
+                      for (var i = 0; i < data.length; i++) {
+                        if (data[i][vmIdMacro] === vmId) {
+                          return JSON.stringify(data[i]);
+                        }
+                      }
+                      throw "ZBX_UNSUPPORTED: VM ID '" + vmId + "' not found";
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1d
               master_item:
                 key: hyperv.discovery.vms
             - uuid: 23ad2a0c2494465d96a19403bfe74edc
@@ -515,8 +561,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "";
                           }
                           return retData;
                         }
@@ -560,8 +610,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "0";
                           }
                           return retData;
                         }
@@ -605,8 +659,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "";
                           }
                           return retData;
                         }
@@ -665,8 +723,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "";
                           }
                           return retData;
                         }
@@ -710,8 +772,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "";
                           }
                           return retData;
                         }
@@ -755,8 +821,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "";
                           }
                           return retData;
                         }
@@ -800,8 +870,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "";
                           }
                           return retData;
                         }
@@ -845,8 +919,12 @@ zabbix_export:
                         var vm = data[i];
                         if (vm[vmIdMacro] === vmId ) {
                           var retData = vm[vmDataMacro];
-                          if (!retData) {
-                            throw "ZBX_UNSUPPORTED: Field "+vmDataMacro+" not found or empty";
+                          // A VM without replication has no primary/replica
+                          // server and no last sync time. That is normal, so
+                          // return a neutral value instead of making the item
+                          // unsupported and alerting on every non replicated VM.
+                          if (retData === undefined || retData === null || retData === "") {
+                            return "";
                           }
                           return retData;
                         }

--- a/Template_Windows_Hyper-V_Host2.yaml
+++ b/Template_Windows_Hyper-V_Host2.yaml
@@ -12,7 +12,7 @@ zabbix_export:
       name: 'Template Windows Hyper-V Host 2'
       vendor:
         name: 'https://github.com/a-schild/Zabbix-HyperV-Templates'
-        version: '2.0.5'
+        version: '2.0.6'
       description: |
         Detect Hyper-V VMs via LLD and create hosts to monitor
         Needs the Template Windows HyperV VM Guest 2 too

--- a/Template_Windows_Hyper-V_VM_Guest_2.yaml
+++ b/Template_Windows_Hyper-V_VM_Guest_2.yaml
@@ -1182,6 +1182,7 @@ zabbix_export:
             - uuid: 36789012abcd4f018789012abc012348
               name: 'Disk {#DISK.ID} - Average Write Latency'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Average sec/Write"]'
+              delay: 5m
               value_type: FLOAT
               status: DISABLED
               discover: NO_DISCOVER
@@ -1191,12 +1192,14 @@ zabbix_export:
             - uuid: 9cf62d67d8d747929da2e9cce796d966
               name: 'Disk {#DISK.ID} - Byte Quota Replenishment Rate'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Byte Quota Replenishment Rate"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Byte Quota Replenishment Rate for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: e15ccda5219a4584bbc142f441dc1a59
               name: 'Disk {#DISK.ID} - Error Count'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Error Count"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Error Count for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
@@ -1211,12 +1214,14 @@ zabbix_export:
             - uuid: 0024b57796ba443eaf2e96c1f9517c35
               name: 'Disk {#DISK.ID} - Flush Count'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Flush Count"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Flush Count for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: 32aee40dd4b748da85efc088efbe58d7
               name: 'Disk {#DISK.ID} - IO Quota Replenishment Rate'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Io Quota Replenishment Rate"]'
+              delay: 5m
               value_type: FLOAT
               status: DISABLED
               discover: NO_DISCOVER
@@ -1224,34 +1229,36 @@ zabbix_export:
               timeout: 30s
             - uuid: cffaaddc2de34fcc8c61bdcb07af71cd
               name: 'Disk {#DISK.ID} - Latency'
-              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",30]'
+              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",300]'
+              delay: 5m
               value_type: FLOAT
               units: s
               description: 'Latency for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
               trigger_prototypes:
                 - uuid: de980912c1d848e6878cd08942c1948f
-                  expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",30])<0.01'
+                  expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",300])<0.01'
                   name: 'Disk {#DISK.ID} latency ok < 10ms'
                   opdata: 'Latency ({ITEM.LASTVALUE1} {ITEM.VALUE1})'
                   status: DISABLED
                   priority: INFO
                 - uuid: 1a9d660132a440af8b2052f6e5bfbcd8
-                  expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",30])>0.015'
+                  expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",300])>0.015'
                   name: 'Disk {#DISK.ID} latency warning > 15ms'
                   opdata: 'Latency ({ITEM.LASTVALUE1} {ITEM.VALUE1})'
                   priority: WARNING
                   dependencies:
                     - name: 'Disk {#DISK.ID} latency warning > 25ms'
-                      expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",30])>0.025'
+                      expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",300])>0.025'
                 - uuid: ac4a41a939ac4eee8d7077bbd4f46e52
-                  expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",30])>0.025'
+                  expression: 'last(/Template Windows Hyper-V VM Guest 2/perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",300])>0.025'
                   name: 'Disk {#DISK.ID} latency warning > 25ms'
                   opdata: 'Latency ({ITEM.LASTVALUE1} {ITEM.VALUE1})'
                   priority: AVERAGE
             - uuid: 25678901abcd4f018678901abc012347
               name: 'Disk {#DISK.ID} - Lower Latency'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Lower Latency"]'
+              delay: 5m
               value_type: FLOAT
               units: s
               description: 'Lower Latency for {#DISK.ID} at {#DISK.PATH}'
@@ -1259,6 +1266,7 @@ zabbix_export:
             - uuid: 5aa9ba08dcb9470fa66f6c137ef6a301
               name: 'Disk {#DISK.ID} - Lower Queue Length'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Lower Queue Length"]'
+              delay: 5m
               value_type: FLOAT
               units: s
               description: 'Lower Queue Length for {#DISK.ID} at {#DISK.PATH}'
@@ -1266,18 +1274,21 @@ zabbix_export:
             - uuid: be5ed5f2658d46f4b8bb5ad79c93c7cc
               name: 'Disk {#DISK.ID} - Maximum Adapter Worker Count'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Maximum Adapter Worker Count"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Maximum Adapter Worker Count for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: cb22af897eaf4ea9a878fe2a34f4e190
               name: 'Disk {#DISK.ID} - Maximum Bandwidth'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Maximum Bandwidth"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Maximum Bandwidth for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: 4e662b9c9ac14cb1a79177c58120ef66
               name: 'Disk {#DISK.ID} - Maximum IO Rate'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Maximum IO Rate"]'
+              delay: 5m
               value_type: FLOAT
               status: DISABLED
               discover: NO_DISCOVER
@@ -1286,6 +1297,7 @@ zabbix_export:
             - uuid: 33085294c6b649dbbb3ccb7deced1f6b
               name: 'Disk {#DISK.ID} - Minimum IO Rate'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Minimum IO Rate"]'
+              delay: 5m
               value_type: FLOAT
               status: DISABLED
               discover: NO_DISCOVER
@@ -1294,6 +1306,7 @@ zabbix_export:
             - uuid: 5851d1ef4a7748ffb53ee514c9afffe4
               name: 'Disk {#DISK.ID} - Normalized Throughput'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Normalized Throughput"]'
+              delay: 5m
               value_type: FLOAT
               units: ops
               description: 'Normalized Throughput for {#DISK.ID} at {#DISK.PATH}'
@@ -1301,12 +1314,14 @@ zabbix_export:
             - uuid: 7f3975ad1e2a4e8d843aa56f5a564e86
               name: 'Disk {#DISK.ID} - Queue Length'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Queue Length"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Queue Length for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: e1f234567890472d9f0123456789abc0
               name: 'Disk {#DISK.ID} - Read Bytes/sec'
-              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Bytes/sec",30]'
+              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Bytes/sec",300]'
+              delay: 5m
               value_type: FLOAT
               units: Bps
               description: 'Disk read throughput for {#DISK.ID} at {#DISK.PATH}'
@@ -1314,12 +1329,14 @@ zabbix_export:
             - uuid: 1913a23214b54c4c8c1fbc3b04367a4a
               name: 'Disk {#DISK.ID} - Read Count'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Count"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Read Count for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: 03456789abcd4f018456789abc012345
               name: 'Disk {#DISK.ID} - Read Operations/sec'
-              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Operations/sec",30]'
+              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Operations/sec",300]'
+              delay: 5m
               value_type: FLOAT
               units: ops
               description: 'Disk read IOPS for {#DISK.ID} at {#DISK.PATH}'
@@ -1327,13 +1344,15 @@ zabbix_export:
             - uuid: bc0d3ed4e9c94cf992201a8dfb557805
               name: 'Disk {#DISK.ID} - Throughput'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Throughput"]'
+              delay: 5m
               value_type: FLOAT
               units: ops
               description: 'Throughput for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: f2345678abcd4f0183456789abc01234
               name: 'Disk {#DISK.ID} - Write Bytes/sec'
-              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Bytes/sec",30]'
+              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Bytes/sec",300]'
+              delay: 5m
               value_type: FLOAT
               units: Bps
               description: 'Disk write throughput for {#DISK.ID} at {#DISK.PATH}'
@@ -1341,12 +1360,14 @@ zabbix_export:
             - uuid: 5417373178af40a4a86da68f8accc1bf
               name: 'Disk {#DISK.ID} - Write Count'
               key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Count"]'
+              delay: 5m
               value_type: FLOAT
               description: 'Write Count for {#DISK.ID} at {#DISK.PATH}'
               timeout: 30s
             - uuid: 14567890abcd4f018567890abc012346
               name: 'Disk {#DISK.ID} - Write Operations/sec'
-              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Operations/sec",30]'
+              key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Operations/sec",300]'
+              delay: 5m
               value_type: FLOAT
               units: ops
               description: 'Disk write IOPS for {#DISK.ID} at {#DISK.PATH}'
@@ -1429,7 +1450,7 @@ zabbix_export:
                   calc_fnc: ALL
                   item:
                     host: 'Template Windows Hyper-V VM Guest 2'
-                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",30]'
+                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",300]'
                 - sortorder: '2'
                   color: F63100
                   calc_fnc: ALL
@@ -1444,32 +1465,32 @@ zabbix_export:
                   calc_fnc: ALL
                   item:
                     host: 'Template Windows Hyper-V VM Guest 2'
-                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Bytes/sec",30]'
+                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Bytes/sec",300]'
                 - sortorder: '1'
                   color: A5D6A7
                   calc_fnc: ALL
                   item:
                     host: 'Template Windows Hyper-V VM Guest 2'
-                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Operations/sec",30]'
+                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Read Operations/sec",300]'
                 - sortorder: '2'
                   color: FFB74D
                   calc_fnc: ALL
                   item:
                     host: 'Template Windows Hyper-V VM Guest 2'
-                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Bytes/sec",30]'
+                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Bytes/sec",300]'
                 - sortorder: '3'
                   color: BA68C8
                   calc_fnc: ALL
                   item:
                     host: 'Template Windows Hyper-V VM Guest 2'
-                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Operations/sec",30]'
+                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Write Operations/sec",300]'
                 - sortorder: '4'
                   color: FF0080
                   yaxisside: RIGHT
                   calc_fnc: ALL
                   item:
                     host: 'Template Windows Hyper-V VM Guest 2'
-                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",30]'
+                    key: 'perf_counter_en["\Hyper-V Virtual Storage Device({#DISK.PATH_COUNTER})\Latency",300]'
             - uuid: abfaff554baf4f689b9064855f533c8b
               name: 'Disk {#DISK.ID} size'
               ymin_type_1: FIXED
@@ -2325,16 +2346,19 @@ zabbix_export:
           value: hyper-v-vm
       macros:
         - macro: '{$VM.DETAILS.INTERVAL}'
-          value: 30m
+          value: 10m
           description: |
             How often the Hyper-V host is asked for this VM's details.
-            Every poll starts a powershell.exe, imports the Hyper-V module and
-            walks the VM config including Get-VHD on every disk, so the cost is
-            one such run per VM per interval. On a host with 20 VMs a 10m
-            interval means a run every 30 seconds.
+
+            RAISE THIS IF THE HOST CPU SUFFERS. Every poll starts a
+            powershell.exe, imports the Hyper-V module and walks the VM config
+            including Get-VHD on every disk, and it runs once per VM per
+            interval. On a host with 20 VMs the 10m default is one such run
+            every 30 seconds; 30m or 60m makes that far less frequent.
+
             The payload is configuration, inventory and checkpoint data, none of
-            which changes by the second. Lower it if you want faster VM state
-            detection, raise it on busy hosts.
+            which changes by the second, so a longer interval costs little
+            besides slower VM state detection.
         - macro: '{$VM.CHECKPOINT.COUNT.MAX}'
           value: '3'
           description: 'Warn above this many checkpoints on a single VM.'

--- a/Template_Windows_Hyper-V_VM_Guest_2.yaml
+++ b/Template_Windows_Hyper-V_VM_Guest_2.yaml
@@ -23,7 +23,7 @@ zabbix_export:
         - uuid: 77b70fa1ac3b41259978c203f4ac34f0
           name: 'Hyper-V VM master data'
           key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
-          delay: 10m
+          delay: '{$VM.DETAILS.INTERVAL}'
           value_type: TEXT
           trends: '0'
           description: |
@@ -33,6 +33,779 @@ zabbix_export:
             
             Needs to be Zabbix agent in passive mode, since the request is sent to the Hyper-V server
           timeout: 30s
+        - uuid: 9622b2ac2b1f4f8b8887129057c8a04b
+          name: 'Checkpoints: count'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.count
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Number of checkpoints (snapshots) currently present for this VM.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.COUNT}"]'
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+          triggers:
+            - uuid: aba804d6efa148fab782cf4dae64656f
+              expression: 'last(/Template Windows Hyper-V VM Guest 2/hyperv.vm.checkpoint.count)>{$VM.CHECKPOINT.COUNT.MAX}'
+              name: 'Hyper-V: too many checkpoints on {HOST.NAME}'
+              priority: WARNING
+              description: |
+                Each checkpoint adds another avhdx to the differencing chain, which costs
+                read performance and disk space. Adjust with {$VM.CHECKPOINT.COUNT.MAX}.
+        - uuid: 382a5623652c42c0a788083d340776f8
+          name: 'Checkpoints: type'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.type
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Checkpoint type configured for this VM (Standard or Production).'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.TYPE}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+        - uuid: 4b0a14b462284d2c8ac983c68628aa0c
+          name: 'Checkpoints: oldest name'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.oldest.name
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Name of the oldest checkpoint. Empty when the VM has no checkpoints.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.OLDEST.NAME}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+        - uuid: bc05a0f7c62744ec97ab9a0462406eec
+          name: 'Checkpoints: oldest created'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.oldest.created
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Creation time of the oldest checkpoint, as local time on the Hyper-V host.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.OLDEST.CREATED}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+        - uuid: dac4cb96a287416faa8571ecf65ad757
+          name: 'Checkpoints: oldest age'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.oldest.age
+          delay: '0'
+          value_type: UNSIGNED
+          units: 's'
+          description: |
+            Age of the oldest checkpoint. Computed on the Hyper-V host, so no timezone
+            correction is needed here. 0 when the VM has no checkpoints.
+            Long lived checkpoints keep growing their avhdx chain and eventually fill
+            the volume, which is what the accompanying trigger watches for.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.OLDEST.AGE}"]'
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+          triggers:
+            - uuid: 84b43c71750e425cb94d85d297dad707
+              expression: 'last(/Template Windows Hyper-V VM Guest 2/hyperv.vm.checkpoint.count)>0 and last(/Template Windows Hyper-V VM Guest 2/hyperv.vm.checkpoint.oldest.age)>{$VM.CHECKPOINT.AGE.MAX}'
+              name: 'Hyper-V: checkpoint older than {$VM.CHECKPOINT.AGE.MAX} on {HOST.NAME}'
+              priority: WARNING
+              description: |
+                A checkpoint has been left behind. Its avhdx keeps growing for as long as
+                it exists and merging it back gets slower the longer it is kept.
+                The count check guards against firing on VMs that have no checkpoints.
+        - uuid: 5bfbfc7c457c46d0a764cf9c554ae543
+          name: 'Checkpoints: newest name'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.newest.name
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Name of the most recent checkpoint. Empty when the VM has no checkpoints.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.NEWEST.NAME}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+        - uuid: 5d25508402f44bc7aca9993b4bcd8a93
+          name: 'Checkpoints: newest created'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.newest.created
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Creation time of the most recent checkpoint, as local time on the Hyper-V host.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.NEWEST.CREATED}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+        - uuid: e9e62a7026ea4c03ba2b0dcfc352efc4
+          name: 'Checkpoints: newest age'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.newest.age
+          delay: '0'
+          value_type: UNSIGNED
+          units: 's'
+          description: 'Age of the most recent checkpoint. 0 when the VM has no checkpoints.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.NEWEST.AGE}"]'
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+        - uuid: 25881f04954d4e389d83d5d052d6e9b0
+          name: 'Checkpoints: details'
+          type: DEPENDENT
+          key: hyperv.vm.checkpoint.info
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Raw json list of all checkpoints: name, creation time, age, parent and type.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CHECKPOINT.INFO}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: checkpoints
+        - uuid: 5bd59090c2084b32ad5dd581f1e4172a
+          name: 'VM name'
+          type: DEPENDENT
+          key: hyperv.vm.name
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Name of the VM as configured on the Hyper-V host.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.NAME}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: 0472e6a7f2794e77ac5404744d600902
+          name: 'VM state'
+          type: DEPENDENT
+          key: hyperv.vm.state
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Run state of the VM: Running, Off, Paused, Saved, ...'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.STATE}"]'
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: state
+          triggers:
+            - uuid: 121f3d8ab4ba45a6827100fde8be70de
+              expression: 'last(/Template Windows Hyper-V VM Guest 2/hyperv.vm.state)<>"Running"'
+              name: 'Hyper-V: VM is not running on {HOST.NAME}'
+              priority: INFO
+              description: |
+                The VM is not in the Running state. Informational by design, since a VM
+                may legitimately be switched off. Disable this trigger on templates or
+                hosts where it is only noise.
+        - uuid: 696a0aefe73c42e69ce365c99a682baa
+          name: 'VM state (numeric)'
+          type: DEPENDENT
+          key: hyperv.vm.state.value
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Run state as the numeric Hyper-V VMState enum value, for graphing.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.STATE.VALUE}"]'
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: state
+        - uuid: f1924b0c64534d8093d02712a4497ec3
+          name: 'VM status'
+          type: DEPENDENT
+          key: hyperv.vm.status
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: |
+            Health status of the VM, normalized to english regardless of the host
+            language (see ConvertToEnglish in hyper-v-monitoring2.ps1).
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.STATUS.TRANSLATED}"]'
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: state
+          triggers:
+            - uuid: 060ec7d23b3d4990b0f2df73d452b71d
+              expression: 'last(/Template Windows Hyper-V VM Guest 2/hyperv.vm.status)<>"Operating normally" and last(/Template Windows Hyper-V VM Guest 2/hyperv.vm.status)<>""'
+              name: 'Hyper-V: VM status is not normal on {HOST.NAME}'
+              priority: WARNING
+              description: |
+                The Hyper-V host reports a degraded status for this VM, for example a
+                failed checkpoint merge, a paused-critical state or a lost connection to
+                its storage.
+        - uuid: ba93b78a94964e25bd11d868b49ec851
+          name: 'VM status (host language)'
+          type: DEPENDENT
+          key: hyperv.vm.status.raw
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Health status exactly as reported by the Hyper-V host, in the host language.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.STATUS}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: state
+        - uuid: 5dde33d559314b07a33cda7aead55ced
+          name: 'VM uptime'
+          type: DEPENDENT
+          key: hyperv.vm.uptime
+          delay: '0'
+          value_type: FLOAT
+          units: 's'
+          description: 'Time since the VM was started. 0 when the VM is not running.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.UPTIME}"]'
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: state
+        - uuid: 2f5c1112539a4992a933e49740d99230
+          name: 'VM generation'
+          type: DEPENDENT
+          key: hyperv.vm.generation
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Hyper-V VM generation (1 or 2).'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.GENERATION}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: 2c6ce1e162724ba08a1b9e35ddc595e0
+          name: 'VM configuration version'
+          type: DEPENDENT
+          key: hyperv.vm.version
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'VM configuration version. An outdated version blocks newer Hyper-V features.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.VERSION}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: 4aa656a8e026430ea1ab8c6748e721cc
+          name: 'CPU: virtual processors'
+          type: DEPENDENT
+          key: hyperv.vm.cpu.count
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Number of virtual processors assigned to the VM.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CPU.COUNT}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: b419b3bd3d1b4b85bd448ba7ecb43840
+          name: 'CPU: reserve'
+          type: DEPENDENT
+          key: hyperv.vm.cpu.reserve
+          delay: '0'
+          value_type: UNSIGNED
+          units: '%'
+          description: 'Percentage of host CPU reserved for this VM.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CPU.RESERVE}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: dc1506eda2974fc291ab0b38419e5492
+          name: 'CPU: limit'
+          type: DEPENDENT
+          key: hyperv.vm.cpu.maximum
+          delay: '0'
+          value_type: UNSIGNED
+          units: '%'
+          description: 'Maximum percentage of host CPU this VM may use.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CPU.MAXIMUM}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: 1fca9eb64491498abe1ae3d140b96a55
+          name: 'CPU: relative weight'
+          type: DEPENDENT
+          key: hyperv.vm.cpu.weight
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Relative scheduling weight against other VMs (default 100).'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CPU.WEIGHT}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: 43c11883d4854394b26ac476986f8b7b
+          name: 'Memory: startup'
+          type: DEPENDENT
+          key: hyperv.vm.memory.startup
+          delay: '0'
+          value_type: UNSIGNED
+          units: 'B'
+          description: |
+            Startup memory. The source lld macro is named .MB for historical reasons
+            but the value is in bytes.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.MEMORY.STARTUP.MB}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 21235481f42246c4a179ca5a3c2a2322
+          name: 'Memory: minimum'
+          type: DEPENDENT
+          key: hyperv.vm.memory.minimum
+          delay: '0'
+          value_type: UNSIGNED
+          units: 'B'
+          description: 'Minimum memory when dynamic memory is enabled. Value is in bytes.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.MEMORY.MINIMUM.MB}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: d7f40e382b7b4b3ebddfd33d70300a41
+          name: 'Memory: maximum'
+          type: DEPENDENT
+          key: hyperv.vm.memory.maximum
+          delay: '0'
+          value_type: UNSIGNED
+          units: 'B'
+          description: 'Maximum memory when dynamic memory is enabled. Value is in bytes.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.MEMORY.MAXIMUM.MB}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 6a223f17b255429eb21c8d28e181cbba
+          name: 'Memory: dynamic enabled'
+          type: DEPENDENT
+          key: hyperv.vm.memory.dynamic
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Whether dynamic memory is enabled for this VM.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.MEMORY.DYNAMIC}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 43be26c607974550a0f29392b4182421
+          name: 'Memory: buffer'
+          type: DEPENDENT
+          key: hyperv.vm.memory.buffer
+          delay: '0'
+          value_type: UNSIGNED
+          units: '%'
+          description: 'Dynamic memory buffer percentage.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.MEMORY.BUFFER}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 1c20bb7758b94501a4d660ecda38fa6b
+          name: 'Memory: weight'
+          type: DEPENDENT
+          key: hyperv.vm.memory.priority
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Memory weight used when the host is under memory pressure.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.MEMORY.PRIORITY}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 529c4140a85243e79c6369b750172d25
+          name: 'Autostart action'
+          type: DEPENDENT
+          key: hyperv.vm.autostart.action
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'What the host does with this VM when it boots.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.AUTOSTART.ACTION}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: 708b60af25ee40bab3451c5444fb2148
+          name: 'Autostart delay'
+          type: DEPENDENT
+          key: hyperv.vm.autostart.delay
+          delay: '0'
+          value_type: UNSIGNED
+          units: 's'
+          description: 'Delay before this VM is started automatically.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.AUTOSTART.DELAY}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: c563709e96d34609bf82d7f558bc5163
+          name: 'Autostop action'
+          type: DEPENDENT
+          key: hyperv.vm.autostop.action
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'What the host does with this VM when it shuts down.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.AUTOSTOP.ACTION}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: c72ebad1557f4e31990f1502039bf195
+          name: 'Configuration path'
+          type: DEPENDENT
+          key: hyperv.vm.config.path
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Directory holding the VM configuration.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.CONFIG.PATH}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: beb644ca30cb4cc4abe8a437b29e799a
+          name: 'Checkpoint path'
+          type: DEPENDENT
+          key: hyperv.vm.snapshot.path
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Directory where checkpoint files are stored.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.SNAPSHOT.PATH}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: b57c8842e19044ba976694d96b9e3062
+          name: 'Smart paging path'
+          type: DEPENDENT
+          key: hyperv.vm.smart.paging.path
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Directory used for smart paging.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.SMART.PAGING.PATH}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: af41ff2da00f4ca3962c851cf56a5df0
+          name: 'Notes'
+          type: DEPENDENT
+          key: hyperv.vm.notes
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Free text notes configured on the VM.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.NOTES}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: 8683f21823ac43ed82d767671dede8fb
+          name: 'Network adapters'
+          type: DEPENDENT
+          key: hyperv.vm.network.count
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Number of virtual network adapters attached.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.NETWORK.COUNT}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: 4dde3f9d1d7746ab98b1cbc0b085c883
+          name: 'Hard disks'
+          type: DEPENDENT
+          key: hyperv.vm.disk.count
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Number of virtual hard disks attached.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.DISK.COUNT}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: 969fb8d32f3340e69d28e0b5b4df8de7
+          name: 'DVD drives'
+          type: DEPENDENT
+          key: hyperv.vm.dvd.count
+          delay: '0'
+          value_type: UNSIGNED
+          description: 'Number of virtual dvd drives attached.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.DVD.COUNT}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
+        - uuid: a4c9057fcfb24e669b526fd5686cc620
+          name: 'Integration services'
+          type: DEPENDENT
+          key: hyperv.vm.integration.info
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Raw json list of the integration services and their state.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.vm_info["{#VM.INTEGRATION.INFO}"]'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: 'hyperv.discovery.vmdetails[{$VM.ID}]'
+          tags:
+            - tag: component
+              value: config
       discovery_rules:
         - uuid: f88de644e4f34b72be0b4ad9ed31d27e
           name: 'VM Disks Discovery'
@@ -1550,6 +2323,24 @@ zabbix_export:
           value: hyper-v
         - tag: target
           value: hyper-v-vm
+      macros:
+        - macro: '{$VM.DETAILS.INTERVAL}'
+          value: 30m
+          description: |
+            How often the Hyper-V host is asked for this VM's details.
+            Every poll starts a powershell.exe, imports the Hyper-V module and
+            walks the VM config including Get-VHD on every disk, so the cost is
+            one such run per VM per interval. On a host with 20 VMs a 10m
+            interval means a run every 30 seconds.
+            The payload is configuration, inventory and checkpoint data, none of
+            which changes by the second. Lower it if you want faster VM state
+            detection, raise it on busy hosts.
+        - macro: '{$VM.CHECKPOINT.COUNT.MAX}'
+          value: '3'
+          description: 'Warn above this many checkpoints on a single VM.'
+        - macro: '{$VM.CHECKPOINT.AGE.MAX}'
+          value: '7d'
+          description: 'Warn when the oldest checkpoint of a VM is older than this.'
       dashboards:
         - uuid: 2f549e6c78ab4c6fb5f31cc5394a0c1a
           name: VM

--- a/Template_Windows_Hyper-V_VM_Guest_2.yaml
+++ b/Template_Windows_Hyper-V_VM_Guest_2.yaml
@@ -13,7 +13,7 @@ zabbix_export:
       name: 'Template Windows Hyper-V VM Guest 2'
       vendor:
         name: 'https://github.com/a-schild/Zabbix-HyperV-Templates'
-        version: '2.0.5'
+        version: '2.0.6'
       description: 'Child template, to create new Hyper-V VM monitoring from the "Template Windows HyperV Host 2" template. See https://github.com/a-schild/Zabbix-HyperV-Templates'
       groups:
         - name: 'HyperV VM'

--- a/hyper-v-monitoring2.ps1
+++ b/hyper-v-monitoring2.ps1
@@ -48,6 +48,90 @@ try {
     Write-DebugInfo "Could not set culture or reload module: $($_.Exception.Message)"
 }
 
+# Describe the integration services of a VM.
+# Names and status texts are localized by Windows, so both the raw and the
+# english value are returned.
+function Get-IntegrationServiceInfo {
+    param($Services)
+
+    $info = @()
+    foreach ($service in $Services) {
+        try {
+            Write-DebugInfo "    Processing service: $($service.Name)"
+            $info += @{
+                "Name" = $service.Name
+                "NameTranslated" = ConvertToEnglish -Value $service.Name
+                "Enabled" = $service.Enabled.ToString()
+                "PrimaryStatusDescription" = $service.PrimaryStatusDescription
+                "PrimaryStatusDescriptionTranslated" = ConvertToEnglish -Value $service.PrimaryStatusDescription
+            }
+        } catch {
+            Write-DebugInfo "    Error processing integration service: $($_.Exception.Message)"
+        }
+    }
+    return ,$info
+}
+
+# Summarize the checkpoints of a VM.
+# Both the 'vms' and the 'vmdetails' payload expose the same fields, so the
+# host template and the VM guest template can monitor checkpoints identically.
+# Ages are computed here, on the Hyper-V host, so no timezone handling is
+# needed on the Zabbix side (CreationTime carries no offset of its own).
+function Get-CheckpointSummary {
+    param($Checkpoints)
+
+    $now = Get-Date
+    $list = @()
+
+    foreach ($checkpoint in $Checkpoints) {
+        try {
+            Write-DebugInfo "    Processing checkpoint: $($checkpoint.Name)"
+            $created = $checkpoint.CreationTime
+            $list += @{
+                "Name" = $checkpoint.Name
+                "CreationTime" = $created.ToString("yyyy-MM-dd HH:mm:ss")
+                "CreationEpoch" = [int64]([System.DateTimeOffset]$created).ToUnixTimeSeconds()
+                "AgeSeconds" = [int64](New-TimeSpan -Start $created -End $now).TotalSeconds
+                "ParentCheckpointName" = $checkpoint.ParentCheckpointName
+                "SnapshotType" = if ($checkpoint.SnapshotType) { $checkpoint.SnapshotType.ToString() } else { "Unknown" }
+            }
+        } catch {
+            Write-DebugInfo "    Error processing checkpoint: $($_.Exception.Message)"
+        }
+    }
+
+    # Sorted oldest first. @() keeps this an array when the VM has one checkpoint.
+    $sorted = @($list | Sort-Object { $_.CreationEpoch })
+
+    $summary = @{
+        "Count" = $sorted.Count
+        "Info" = $sorted
+        "OldestName" = ""
+        "OldestCreated" = ""
+        "OldestEpoch" = 0
+        "OldestAge" = 0
+        "NewestName" = ""
+        "NewestCreated" = ""
+        "NewestEpoch" = 0
+        "NewestAge" = 0
+    }
+
+    if ($sorted.Count -gt 0) {
+        $oldest = $sorted[0]
+        $newest = $sorted[$sorted.Count - 1]
+        $summary["OldestName"] = $oldest.Name
+        $summary["OldestCreated"] = $oldest.CreationTime
+        $summary["OldestEpoch"] = $oldest.CreationEpoch
+        $summary["OldestAge"] = $oldest.AgeSeconds
+        $summary["NewestName"] = $newest.Name
+        $summary["NewestCreated"] = $newest.CreationTime
+        $summary["NewestEpoch"] = $newest.CreationEpoch
+        $summary["NewestAge"] = $newest.AgeSeconds
+    }
+
+    return $summary
+}
+
 # Convert localized terms to English while preserving original values
 function ConvertToEnglish {
     param($Value)
@@ -271,39 +355,14 @@ function Get-VMDiscoveryData {
             
             # Build integration services info
             Write-DebugInfo "  Building integration services info for $($vm.Name)"
-            $integrationInfo = @()
-            foreach ($service in $vmIntegrationServices) {
-                try {
-                    Write-DebugInfo "    Processing service: $($service.Name)"
-                    $integrationInfo += @{
-                        "Name" = $service.Name
-                        "NameTranslated" = ConvertToEnglish -Value $service.Name
-                        "Enabled" = $service.Enabled.ToString()
-                        "PrimaryStatusDescription" = $service.PrimaryStatusDescription
-                        "PrimaryStatusDescriptionTranslated" = ConvertToEnglish -Value $service.PrimaryStatusDescription
-                    }
-                } catch {
-                    Write-DebugInfo "    Error processing integration service: $($_.Exception.Message)"
-                }
-            }
+            $integrationInfo = Get-IntegrationServiceInfo -Services $vmIntegrationServices
             
             # Get checkpoint information
             Write-DebugInfo "  Getting checkpoints for $($vm.Name)"
             $checkpoints = Get-VMSnapshot -VM $vm -ErrorAction SilentlyContinue
             Write-DebugInfo "    Found $($checkpoints.Count) checkpoints"
-            $checkpointInfo = @()
-            foreach ($checkpoint in $checkpoints) {
-                try {
-                    Write-DebugInfo "    Processing checkpoint: $($checkpoint.Name)"
-                    $checkpointInfo += @{
-                        "Name" = $checkpoint.Name
-                        "CreationTime" = $checkpoint.CreationTime.ToString("yyyy-MM-dd HH:mm:ss")
-                        "ParentCheckpointName" = $checkpoint.ParentCheckpointName
-                    }
-                } catch {
-                    Write-DebugInfo "    Error processing checkpoint: $($_.Exception.Message)"
-                }
-            }
+            $checkpointSummary = Get-CheckpointSummary -Checkpoints $checkpoints
+            $checkpointInfo = $checkpointSummary.Info
 
             # Get replication information
             Write-DebugInfo "  Getting replication status for $($vm.Name)"
@@ -372,7 +431,15 @@ function Get-VMDiscoveryData {
                 "{#VM.NETWORK.COUNT}" = $vmNetworkAdapters.Count.ToString()
                 "{#VM.DISK.COUNT}" = $vmHardDisks.Count.ToString()
                 "{#VM.DVD.COUNT}" = $vmDvdDrives.Count.ToString()
-                "{#VM.CHECKPOINT.COUNT}" = $checkpoints.Count.ToString()
+                "{#VM.CHECKPOINT.COUNT}" = $checkpointSummary.Count.ToString()
+                "{#VM.CHECKPOINT.OLDEST.NAME}" = $checkpointSummary.OldestName
+                "{#VM.CHECKPOINT.OLDEST.CREATED}" = $checkpointSummary.OldestCreated
+                "{#VM.CHECKPOINT.OLDEST.EPOCH}" = $checkpointSummary.OldestEpoch.ToString()
+                "{#VM.CHECKPOINT.OLDEST.AGE}" = $checkpointSummary.OldestAge.ToString()
+                "{#VM.CHECKPOINT.NEWEST.NAME}" = $checkpointSummary.NewestName
+                "{#VM.CHECKPOINT.NEWEST.CREATED}" = $checkpointSummary.NewestCreated
+                "{#VM.CHECKPOINT.NEWEST.EPOCH}" = $checkpointSummary.NewestEpoch.ToString()
+                "{#VM.CHECKPOINT.NEWEST.AGE}" = $checkpointSummary.NewestAge.ToString()
                 # -InputObject so a VM with a single nic/disk/dvd/checkpoint still
                 # yields a json array in these embedded payloads, not a bare object
                 "{#VM.NETWORK.INFO}" = (ConvertTo-Json -InputObject $networkInfo -Compress)
@@ -731,6 +798,7 @@ function Get-VMDetailsById {
         $vmDvdDrives = Get-VMDvdDrive -VM $vm -ErrorAction Stop
         $vmIntegrationServices = Get-VMIntegrationService -VM $vm -ErrorAction Stop
         $checkpoints = Get-VMSnapshot -VM $vm -ErrorAction SilentlyContinue
+        $checkpointSummary = Get-CheckpointSummary -Checkpoints $checkpoints
 
         # Build network adapter LLD data
         Write-DebugInfo "Building network adapter LLD data for $($vm.Name)"
@@ -966,10 +1034,21 @@ function Get-VMDetailsById {
                 "{#VM.NETWORK.COUNT}" = $vmNetworkAdapters.Count.ToString()
                 "{#VM.DISK.COUNT}" = $vmHardDisks.Count.ToString()
                 "{#VM.DVD.COUNT}" = $vmDvdDrives.Count.ToString()
-                "{#VM.CHECKPOINT.COUNT}" = $checkpoints.Count.ToString()
+                "{#VM.CHECKPOINT.COUNT}" = $checkpointSummary.Count.ToString()
+                "{#VM.CHECKPOINT.OLDEST.NAME}" = $checkpointSummary.OldestName
+                "{#VM.CHECKPOINT.OLDEST.CREATED}" = $checkpointSummary.OldestCreated
+                "{#VM.CHECKPOINT.OLDEST.EPOCH}" = $checkpointSummary.OldestEpoch.ToString()
+                "{#VM.CHECKPOINT.OLDEST.AGE}" = $checkpointSummary.OldestAge.ToString()
+                "{#VM.CHECKPOINT.NEWEST.NAME}" = $checkpointSummary.NewestName
+                "{#VM.CHECKPOINT.NEWEST.CREATED}" = $checkpointSummary.NewestCreated
+                "{#VM.CHECKPOINT.NEWEST.EPOCH}" = $checkpointSummary.NewestEpoch.ToString()
+                "{#VM.CHECKPOINT.NEWEST.AGE}" = $checkpointSummary.NewestAge.ToString()
+                "{#VM.CHECKPOINT.INFO}" = (ConvertTo-Json -InputObject $checkpointSummary.Info -Compress)
+                "{#VM.INTEGRATION.INFO}" = (ConvertTo-Json -InputObject (Get-IntegrationServiceInfo -Services $vmIntegrationServices) -Compress)
             }
             "networks" = @($networkLLD)
             "disks" = @($diskLLD)
+            "checkpoints" = @($checkpointSummary.Info)
         }
 
         Write-DebugInfo "VM details discovery completed for $($vm.Name)"
@@ -983,6 +1062,7 @@ function Get-VMDetailsById {
             "vm_info" = @{}
             "networks" = @()
             "disks" = @()
+            "checkpoints" = @()
         } | ConvertTo-Json -Depth 5
     }
 }


### PR DESCRIPTION
Addresses #47, most of #45, and the spiky half of #40.

## The common root cause

Nothing in either template read the `vm_info` block of the vmdetails payload — the guest template's javascript only ever touched `data.disks` and `data.networks`. Around 35 fields per VM were collected every poll and discarded. That is simultaneously the missing checkpoint monitoring of #47 and the *"I dont see any informations about the VMs like memory, CPU only Disks and NICs"* of #45.

## Checkpoints (#47)

`Get-CheckpointSummary` reports the oldest and newest checkpoint — name, creation time, epoch, age — in **both** payloads, so the host and guest templates can monitor checkpoints identically. Ages are computed on the Hyper-V host: the existing `CreationTime` string carries no timezone, so anything derived from it server-side would be off by the host offset.

The guest template gets count, type, oldest/newest name + created + age, and the raw list. Two triggers: too many checkpoints (`{$VM.CHECKPOINT.COUNT.MAX}`, default 3) and a checkpoint left behind (`{$VM.CHECKPOINT.AGE.MAX}`, default 7d, guarded by count > 0 so it cannot fire on VMs that have none).

## The rest of vm_info (#45)

38 dependent items on the **existing** master item, so no extra agent or script calls: state, status, uptime, generation, configuration version, vCPU count/reserve/limit/weight, memory startup/min/max/dynamic/buffer/weight, autostart and autostop, config/checkpoint/smart-paging paths, notes, adapter/disk/dvd counts, integration services. Plus triggers for a VM status that is not "Operating normally" and a VM that is not running (INFO, since VMs are legitimately switched off).

`{#VM.INTEGRATION.INFO}` is now emitted by vmdetails too — `Get-VMIntegrationService` was already being called there and its result thrown away.

## The other three #45 reports

- **`Replication Data` failed on every VM.** A dependent item with no preprocessing and no explicit `value_type`, so it defaulted to Numeric (unsigned) and received the whole VM array: `Value of type "string" is not suitable for value type "Numeric (unsigned)"`. Now TEXT, extracting its own VM's record. Its key also had a stray `$` (`hyperv.vm.data[${#VM.ID}]`).
- **Replication items threw on empty fields.** A VM without replication legitimately has no primary server, no replica server and no last sync time, so `if (!retData) throw` left three permanently unsupported items on every non-replicated VM. They now return an empty value (`"0"` for the numeric frequency) and only throw when the VM is genuinely absent from the payload.
- **Undocumented dependency.** `Hyper-V Host free memory` is calculated from `vm.memory.size[total]` / `[used]`, which come from a windows agent template, not this one. #45's author had linked no other template, hence `Cannot evaluate function: item ... does not exist`. Now documented in the item, the template description and the readme.

## Performance (#40)

The vmdetails master item runs **once per VM per interval**, and each run starts a `powershell.exe`, imports the Hyper-V module and calls `Get-VHD` on every disk. At the 10m interval a 20-VM host means one such run **every 30 seconds** - exactly the reported "100% CPU for 5-10 seconds, reliably every 30 seconds".

- The interval is now the `{$VM.DETAILS.INTERVAL}` macro. **The default stays 10m**, so nothing changes for existing installs; the macro is there so busy hosts can raise it to 30m or 60m.
- **Disk counters move from 1m to 5m.** 16 of the 21 are queried on demand at poll time, so that is five times fewer agent queries per disk per VM.
- The other five carry an averaging window and are sampled by the agent **once a second regardless of the polling interval**, so polling them at 5m while averaging only 30s would have shown 30 seconds out of every 300. Their window moves to `300`, making the value a true 5 minute average. **This changes their item key**, so Zabbix treats them as new items and history for those five per disk **starts fresh**. All 15 references - item keys, four trigger expressions and the graph prototypes - were rewritten together.
- Network counters are left at 1m.

## Verification

No Hyper-V host available here, so this was verified structurally and functionally where possible:

- Both templates parse; all 136 + 79 uuids unique; every new item is DEPENDENT on the right master item with a jsonpath.
- **Cross-checked every jsonpath against what the script actually emits** — this caught `{#VM.INTEGRATION.INFO}` being read but never produced.
- `Get-CheckpointSummary` exercised with stub data: zero checkpoints → zeros and `[]`, a single checkpoint stays an array, ordering correct oldest-first.
- All 16 patched replication javascript blocks executed under node against a replicated and a non-replicated VM: 18/18 evaluate without throwing, empty fields yield empty values.
- Script parses clean under Windows PowerShell 5.1, UTF-8 BOM preserved.

Still needs a real import into a Zabbix server and a run against a live Hyper-V host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

