### PR TITLE
docs: requirements and troubleshooting for the setup traps (#39)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+- 2026-08-10 (unreleased)
+  - README: added a Requirements section and a troubleshooting section keyed on
+    the actual error messages (#39). It now states that the Hyper-V host needs
+    a Zabbix Agent interface, and that the VM guest items are passive checks,
+    so the server has to be able to reach the agent on port 10050. The host
+    template is active and the guest template is passive, which is why a
+    firewalled or Zabbix Cloud setup shows a perfectly healthy Hyper-V host and
+    nothing but unavailable VMs. On site Zabbix proxy is the recommended fix.
+
 - 2026-08-10
   - Release v2.0.6
   - Checkpoint monitoring (#47). The script already collected checkpoints but

--- a/README.md
+++ b/README.md
@@ -45,6 +45,40 @@ The following _host_ parameters are monitored:
 	* Hyper-V Virtual Switch(*)\Bytes
 	* Hyper-V Virtual Machine Health Summary\Health Critical
 	
+## Requirements
+
+Before importing anything, check these three. Most of the reported problems come
+from one of them.
+
+* **The Hyper-V host needs a Zabbix "Agent" interface.** Not just a host entry -
+  an interface of type *Agent*, pointing at the Hyper-V host, port 10050. The
+  discovered VM hosts inherit it. Without it, linking the template fails with
+  `Cannot inherit LLD rule with key "hyperv.discover.vms" ... because a host
+  interface of type "Agent" is required.`
+
+* **The Zabbix server (or a proxy) must be able to reach that agent on port
+  10050.** The two templates are deliberately different here:
+
+  | Template | Check type | Direction |
+  |---|---|---|
+  | Hyper-V Host | active | agent connects out to the server |
+  | Hyper-V VM Guest | passive | **server connects in to the agent** |
+
+  Every VM guest item is a passive check, because the performance counters for a
+  VM live on the Hyper-V host and the VMs have no agent of their own. If the
+  server cannot open a connection to the host's agent, the Hyper-V host itself
+  will look perfectly healthy while **every discovered VM stays unavailable**
+  with `cannot establish TCP connection to [x.x.x.x]:10050: timed out`.
+
+  This bites hardest with **Zabbix Cloud**, or any setup where the server is not
+  on the same network as the Hyper-V host: the server sits on the internet and
+  the host is behind NAT. Either allow inbound 10050 from the server, or - much
+  better - **run a Zabbix proxy on site**. The proxy connects outbound to the
+  cloud server and polls the agent locally, so nothing needs to be exposed.
+
+* **A Windows agent template must be linked to the Hyper-V host as well**, for
+  example "Windows by Zabbix agent". See the note under Usage below.
+
 ## Usage
 * Import provided templates in this order
   1. Template_Windows_HyperV_VM_Guest2.xml (or the yaml version)
@@ -168,6 +202,41 @@ Copyright (C) 2016 Microsoft Corporation. All rights reserved.
 ```
 
 
+## Troubleshooting by error message
+
+**`Cannot inherit LLD rule with key "hyperv.discover.vms" ... because a host
+interface of type "Agent" is required`** when linking the template.
+The Hyper-V host has no Agent interface. Add one (type *Agent*, the host's
+address, port 10050) and link the template again.
+
+**`Cannot find the "data" array in the received JSON object`** on
+`hyperv.discover.vms.data`, usually on a host with only one VM.
+A bug in versions before 2.0.5: a single VM was serialized as a json object
+instead of a one element array. Upgrade `hyper-v-monitoring2.ps1` on the
+Hyper-V host to 2.0.5 or newer. Re-importing the templates alone does not help,
+the fix is in the script.
+
+**`cannot establish TCP connection to [x.x.x.x]:10050: timed out`** on the
+discovered VM hosts, while the Hyper-V host itself reports fine.
+The VM guest items are passive checks, so the server has to reach the agent.
+See Requirements above - with Zabbix Cloud or any server outside the host's
+network, run a Zabbix proxy on site.
+
+**`Cannot evaluate function: item "vm.memory.size[total]" does not exist`**.
+Link a Windows agent template to the Hyper-V host, that is where those items
+come from.
+
+**`Value of type "string" is not suitable for value type "Numeric (unsigned)"`**
+or **`ZBX_UNSUPPORTED: Field {#VM.REPLICATION.PRIMARY.SERVER} not found or
+empty`**.
+Both fixed in 2.0.6, re-import the templates.
+
+**VM hosts are never created**, and the discovery shows no error.
+Discovery runs hourly and the VM details every 29 minutes, so allow up to about
+1.5 hours. If nothing appears after that, check that the "Hyper-V VMS master
+data" item on the Hyper-V host actually has a value, and that both templates
+were imported.
+
 ## F.A.Q.
 
 - Depending on the load of your Hyper-V server, you will have to increase the default
@@ -175,6 +244,7 @@ Copyright (C) 2016 Microsoft Corporation. All rights reserved.
 
 - The Hyper-V Host needs to be setup to use passive Zabbix agent.
   The active agent won't work, as the VM's don't have an active agent inside
+  See the Requirements section for what that means for firewalls and Zabbix Cloud.
   
 - Make sure the agent is allowed to execute the hyper-v-monitoring2.ps1 file.
   For this open a cmd console in the `C:\Program Files\Zabbix Agent 2` location


### PR DESCRIPTION
#39 turned out to be three separate problems, and two of them were undocumented rather than broken.

**1. The Agent interface.** The Hyper-V host needs a Zabbix interface of type *Agent*, not just a host entry. Without one, linking fails with `Cannot inherit LLD rule ... because a host interface of type "Agent" is required`. That was diagnosed in the thread but never made it into the readme.

**2. Passive vs active.** The item types are completely asymmetric:

| Template | Active items | Passive items |
|---|---|---|
| Hyper-V Host | 24 | 0 |
| VM Guest | 0 | 48 |

Every VM guest item is passive because a VM's performance counters live on the Hyper-V host and the VMs have no agent of their own. So the **server** has to open connections to the host's agent on 10050. When it cannot, the Hyper-V host looks perfectly healthy while every discovered VM sits unavailable with `cannot establish TCP connection to [x.x.x.x]:10050: timed out` — precisely what the reporter saw running Zabbix Cloud against a NATed host. An on-site Zabbix proxy is the right answer: it polls the agent locally and connects outbound to the cloud.

This is a design constraint, not a bug. Zabbix active checks cannot collect on behalf of a different host, so the guest items cannot be converted.

**3.** Their `Cannot find the "data" array` error was the single-VM bug, already fixed in v2.0.5. Their pasted `{#VM.DISK.INFO}` is a bare object rather than an array, which is the same single-element serialization fault.

Adds a **Requirements** section before Usage and a **Troubleshooting by error message** section keyed on the literal error strings, so they are searchable. The troubleshooting section also covers the errors fixed in v2.0.5 and v2.0.6, including the reminder that script-side fixes need the script redeployed and not just a template re-import.

Documentation only — no template or script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
